### PR TITLE
NSArray compose method update

### DIFF
--- a/Sources/Foundation/NSArray/NSArray+FunctionalOperators.h
+++ b/Sources/Foundation/NSArray/NSArray+FunctionalOperators.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
  Returns an array composed with another array using the given block.
  Returns an empty array if block is not provided.
  */
-- (NSArray *)composeWithArray:(NSArray *)array usingBlock:(id _Nullable (^)(T firstItem, id secondItem))block;
+- (NSArray *)composeWithArray:(NSArray *)array usingBlock:(id _Nonnull (^)(T firstItem, id secondItem))block;
 
 @end
 

--- a/Sources/Foundation/NSArray/NSArray+FunctionalOperators.m
+++ b/Sources/Foundation/NSArray/NSArray+FunctionalOperators.m
@@ -77,7 +77,7 @@
     return result;
 }
 
-- (NSArray *)composeWithArray:(NSArray *)array usingBlock:(id _Nullable (^)(id firstItem, id secondItem))block
+- (NSArray *)composeWithArray:(NSArray *)array usingBlock:(id _Nonnull (^)(id firstItem, id secondItem))block
 {
     if (!block) {
         return [NSArray new];
@@ -89,7 +89,7 @@
     NSMutableArray *result = [NSMutableArray new];
     
     [enumeratingArray enumerateObjectsUsingBlock:^(id _Nonnull item, NSUInteger index, BOOL *stop) {
-        id blockResult = block(item, secondArray[index]);
+        id blockResult = isFirstArraySmaller ? block(item, secondArray[index]) : block(secondArray[index], item);
         if (blockResult) { [result addObject:blockResult]; }
     }];
     

--- a/Sources/Foundation/NSMutableArray/NSMutableArray+FunctionalOperators.h
+++ b/Sources/Foundation/NSMutableArray/NSMutableArray+FunctionalOperators.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  Returns a mutable array composed with another mutable array using the given block.
  Returns an empty mutable array if block is not provided.
  */
-- (NSMutableArray *)composeWithArray:(NSArray *)array usingBlock:(id _Nullable (^)(T firstItem, id secondItem))block;
+- (NSMutableArray *)composeWithArray:(NSArray *)array usingBlock:(id _Nonnull (^)(T firstItem, id secondItem))block;
 
 @end
 

--- a/Sources/Foundation/NSMutableArray/NSMutableArray+FunctionalOperators.m
+++ b/Sources/Foundation/NSMutableArray/NSMutableArray+FunctionalOperators.m
@@ -57,7 +57,7 @@
     return result;
 }
 
-- (NSMutableArray *)composeWithArray:(NSArray *)array usingBlock:(id _Nullable (^)(id firstItem, id secondItem))block
+- (NSMutableArray *)composeWithArray:(NSArray *)array usingBlock:(id _Nonnull (^)(id firstItem, id secondItem))block
 {
     if (!block) {
         return [NSMutableArray new];
@@ -69,7 +69,7 @@
     NSMutableArray *result = [NSMutableArray new];
     
     [enumeratingArray enumerateObjectsUsingBlock:^(id _Nonnull item, NSUInteger index, BOOL *stop) {
-        id blockResult = block(item, secondArray[index]);
+        id blockResult = isFirstArraySmaller ? block(item, secondArray[index]) : block(secondArray[index], item);
         if (blockResult) { [result addObject:blockResult]; }
     }];
     

--- a/Tests/Foundation/NSArray/NSArray+FunctionalOperatorsTests.m
+++ b/Tests/Foundation/NSArray/NSArray+FunctionalOperatorsTests.m
@@ -101,4 +101,42 @@
     XCTAssertTrue([expected[1] isEqual:result[1].color]);
 }
 
+- (void)testArrayComposeOperatorWithSmallerArray
+{
+    NSArrayTestModel *modelOne = [NSArrayTestModel new];
+    modelOne.firstTestString = @"This";
+    NSArrayTestModel *modelTwo = [NSArrayTestModel new];
+    modelTwo.firstTestString = @"That";
+    
+    NSArray<NSArrayTestModel *> *values = @[modelOne, modelTwo];
+    NSArray<UIColor *> *otherValues = @[[UIColor whiteColor]];
+    NSArray<NSArrayTestModel *> *result = [values composeWithArray:otherValues usingBlock:^NSArrayTestModel *(NSArrayTestModel *firstItem, UIColor *secondItem) {
+        firstItem.color = secondItem;
+        return firstItem;
+    }];
+    
+    UIColor *firstModelColor = [UIColor whiteColor];
+    NSArray<UIColor *> *expected = @[firstModelColor];
+    
+    XCTAssertTrue([expected[0] isEqual:result[0].color]);
+    XCTAssertTrue([result count] == 1);
+}
+
+- (void)testArrayComposeOperatorWithEmptyArray
+{
+    NSArrayTestModel *modelOne = [NSArrayTestModel new];
+    modelOne.firstTestString = @"This";
+    NSArrayTestModel *modelTwo = [NSArrayTestModel new];
+    modelTwo.firstTestString = @"That";
+    
+    NSArray<NSArrayTestModel *> *values = @[modelOne, modelTwo];
+    NSArray<UIColor *> *otherValues = @[];
+    NSArray<NSArrayTestModel *> *result = [values composeWithArray:otherValues usingBlock:^NSArrayTestModel *(NSArrayTestModel *firstItem, UIColor *secondItem) {
+        firstItem.color = secondItem;
+        return firstItem;
+    }];
+    
+    XCTAssertTrue([result count] == 0);
+}
+
 @end

--- a/Tests/Foundation/NSMutableArray/NSMutableArray+FunctionalOperatorsTests.m
+++ b/Tests/Foundation/NSMutableArray/NSMutableArray+FunctionalOperatorsTests.m
@@ -99,4 +99,42 @@
     XCTAssertTrue([expected[0] isEqual:result[0].color]);
 }
 
+- (void)testMutableArrayComposeOperatorWithSmallerArray
+{
+    NSArrayTestModel *modelOne = [NSArrayTestModel new];
+    modelOne.firstTestString = @"This";
+    NSArrayTestModel *modelTwo = [NSArrayTestModel new];
+    modelTwo.firstTestString = @"That";
+    
+    NSMutableArray<NSArrayTestModel *> *values = [[NSMutableArray alloc] initWithArray:@[modelOne, modelTwo]];
+    NSMutableArray<UIColor *> *otherValues = [[NSMutableArray alloc] initWithArray:@[[UIColor whiteColor]]];
+    NSMutableArray<NSArrayTestModel *> *result = [values composeWithArray:otherValues usingBlock:^NSArrayTestModel *(NSArrayTestModel *firstItem, UIColor *secondItem) {
+        firstItem.color = secondItem;
+        return firstItem;
+    }];
+    
+    UIColor *firstModelColor = [UIColor whiteColor];
+    NSMutableArray<UIColor *> *expected = [[NSMutableArray alloc] initWithArray:@[firstModelColor]];
+
+    XCTAssertTrue([expected[0] isEqual:result[0].color]);
+    XCTAssertTrue([result count] == 1);
+}
+
+- (void)testMutableArrayComposeOperatorWithEmptyArray
+{
+    NSArrayTestModel *modelOne = [NSArrayTestModel new];
+    modelOne.firstTestString = @"This";
+    NSArrayTestModel *modelTwo = [NSArrayTestModel new];
+    modelTwo.firstTestString = @"That";
+    
+    NSMutableArray<NSArrayTestModel *> *values = [[NSMutableArray alloc] initWithArray:@[modelOne, modelTwo]];
+    NSMutableArray<UIColor *> *otherValues = [NSMutableArray new];
+    NSMutableArray<NSArrayTestModel *> *result = [values composeWithArray:otherValues usingBlock:^NSArrayTestModel *(NSArrayTestModel *firstItem, UIColor *secondItem) {
+        firstItem.color = secondItem;
+        return firstItem;
+    }];
+    
+    XCTAssertTrue([result count] == 0);
+}
+
 @end


### PR DESCRIPTION
Block must not return null.
Fixed an error that occurred when using two arrays of different sizes.
Added two new test to test if method works when one array is smaller than the other and if method returns empty array when one of the array is empty.

# Description

Please include a summary of the feature you have added.

# Checklist:

<!--
Put `x` inside brackets for confirmation: [x]
-->

- [x] Have checked there is no same component already in catalog.
- [x] Have created a sufficient example or wrote tests for it.
- [x] Code is structured, well written using standard Swift coding style.
- [ ] All public methods and properties have meaningful and concise documentation.
- [ ] Used `public` modifier for all method and properties that could be changed from user of your feature, and `private` for internal properties.
- [x] Removed any reference to the project that piece of code was created in.
- [x] Reduced the dependencies to minimum.
