### PR TITLE
Updating ObjC version of TableDataSourceDelegate.

### DIFF
--- a/Sources/UI/DataSourceDelegate/ObjC/CellItem.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/CellItem.h
@@ -7,6 +7,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Base protocol for all possible kinds of cell items like
 /// collection view cell item, table view cell item.
 ///
@@ -14,3 +16,5 @@
 @protocol CellItem <NSObject>
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/UI/DataSourceDelegate/ObjC/CollectionView/BaseCollectionCellItem/BaseCollectionCellItem.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/CollectionView/BaseCollectionCellItem/BaseCollectionCellItem.h
@@ -8,6 +8,10 @@
 #import <Foundation/Foundation.h>
 #import "CollectionCellItem.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface BaseCollectionCellItem : NSObject <CollectionCellItem>
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/UI/DataSourceDelegate/ObjC/CollectionView/BaseCollectionSection/BaseCollectionSection.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/CollectionView/BaseCollectionSection/BaseCollectionSection.h
@@ -8,6 +8,8 @@
 #import <Foundation/Foundation.h>
 #import "CollectionSectionItem.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface BaseCollectionSection : NSObject <CollectionSectionItem>
 
 @property (nonatomic, strong) NSArray<id<CollectionCellItem>> *items;
@@ -15,3 +17,5 @@
 - (instancetype)initWithItems:(NSArray<id<CollectionCellItem>> *) items;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/UI/DataSourceDelegate/ObjC/CollectionView/BaseCollectionSection/BaseCollectionSection.m
+++ b/Sources/UI/DataSourceDelegate/ObjC/CollectionView/BaseCollectionSection/BaseCollectionSection.m
@@ -9,7 +9,7 @@
 
 @implementation BaseCollectionSection
 
-- (instancetype)initWithItems:(NSArray<id> *)items
+- (instancetype)initWithItems:(NSArray<id<CollectionCellItem>> *)items
 {
     self = [super init];
     if (self) {

--- a/Sources/UI/DataSourceDelegate/ObjC/CollectionView/CollectionCellItem.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/CollectionView/CollectionCellItem.h
@@ -8,6 +8,8 @@
 #import <UIKit/UIKit.h>
 #import "CellItem.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Base interface for all collection view cell items - used in conjuction with
 /// `CollectionDataSourceDelegate`
 @protocol CollectionCellItem <NSObject, CellItem>
@@ -52,3 +54,5 @@
 - (void)didSelectAt:(NSIndexPath *)indexPath;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/UI/DataSourceDelegate/ObjC/CollectionView/CollectionCellItem.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/CollectionView/CollectionCellItem.h
@@ -22,35 +22,29 @@ NS_ASSUME_NONNULL_BEGIN
 /// Dequeued cell should be configured with current item before
 /// returning it.
 ///
-/// - Parameters:
-///   - collectionView: parent collection view
-///   - indexPath: index path of cell to configure
-/// - Returns: Dequeued, configured and reused cell
+/// @param collectionView Parent collection view
+/// @param indexPath Index path of cell to configure
 - (__kindof UICollectionViewCell *)cellFromCollectionView:(UICollectionView *)collectionView at:(NSIndexPath *)indexPath;
 
 #pragma mark - Optional methods and properties
 
 /// Size for item's cell
 ///
-/// - Parameters:
-///   - collectionViewSize: Size of a parent collection view
-///   - layout: Used flow layout
-///   - indexPath: cell index path
-///   - numberOfItemsInSection: number of items in current section
-/// - Returns: Size for item's cell
+/// @param collectionViewSize Size of a parent collection view
+/// @param layout Used flow layout
+/// @param indexPath Cell index path
+/// @param numberOfItemsInSection Number of items in current section
 - (CGSize)itemSizeForCollectionViewSize:(CGSize)collectionViewSize layout:(UICollectionViewLayout *)layout at:(NSIndexPath *)indexPath numberOfItemsInSection:(NSInteger)numberOfItemsInSection;
 
 /// Notification before cell will be displayed - use this method
 /// for configuring complex cell layout
 ///
-/// - Parameters:
-///   - cell: Item's collection view cell
-///   - indexPath: Item's index path
+/// @param cell Item's collection view cell
+/// @param indexPath Item's index path
 - (void)willDisplayCell:(UICollectionViewCell *)cell at:(NSIndexPath *)indexPath;
 
 /// Notifies cell item when user selects collection view cell.
-///
-/// - Parameter indexPath: index path of a selected cell
+/// @param indexPath Index path of a selected cell
 - (void)didSelectAt:(NSIndexPath *)indexPath;
 
 @end

--- a/Sources/UI/DataSourceDelegate/ObjC/CollectionView/CollectionDataSourceDelegate/CollectionDataSourceDelegate.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/CollectionView/CollectionDataSourceDelegate/CollectionDataSourceDelegate.h
@@ -38,8 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Object will have DefaultTableViewReloader as reloader.
 ///
-/// - Parameters:
-///   - collectionView: Collection view to control
+/// @param collectionView Collection view to control
 - (instancetype)initWithCollectionView:(UICollectionView *)collectionView;
 
 /// Creates a new data source delegate object responsible for handling
@@ -51,9 +50,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Freely use `delegate` property since internally data source delegate will
 /// use pass through delegate.
 ///
-/// - Parameters:
-///   - collectionView: Collection view to control
-///   - reloader: Data reloader
+/// @param collectionView Collection view to control
+/// @param reloader Data reloader
 - (instancetype)initWithCollectionView:(UICollectionView *)collectionView
                               reloader:(id<CollectionViewReloader>)reloader;
 

--- a/Sources/UI/DataSourceDelegate/ObjC/CollectionView/CollectionDataSourceDelegate/CollectionDataSourceDelegate.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/CollectionView/CollectionDataSourceDelegate/CollectionDataSourceDelegate.h
@@ -10,6 +10,8 @@
 #import "CollectionCellItem.h"
 #import "CollectionViewReloader.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Object serving as a data source and delegate for a collection view.
 /// Main purpose is to reduce a boilerplate when dealing with simple
 /// collection view data displaying.
@@ -57,3 +59,4 @@
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/Sources/UI/DataSourceDelegate/ObjC/CollectionView/CollectionSectionItem.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/CollectionView/CollectionSectionItem.h
@@ -9,6 +9,8 @@
 #import "SectionItem.h"
 #import "CollectionCellItem.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol CollectionSectionItem <NSObject, SectionItem>
 
 #pragma mark - Required methods and properties
@@ -17,3 +19,4 @@
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/Sources/UI/DataSourceDelegate/ObjC/CollectionView/Reloader/CollectionViewReloader.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/CollectionView/Reloader/CollectionViewReloader.h
@@ -16,10 +16,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Called when new data arrives and reload is necessary
 ///
-/// - Parameters:
-///   - collectionView: Current collection view
-///   - oldSections: Previous sections/items
-///   - newSections: New sections/items
+/// @param collectionView Current collection view
+/// @param oldSections Previous sections/items
+/// @param newSections New sections/items
 - (void)reloadCollectionView:(UICollectionView *)collectionView
                  oldSections:(NSArray<id<CollectionSectionItem>> *)oldSections
                  newSections:(NSArray<id<CollectionSectionItem>> *)newSections;

--- a/Sources/UI/DataSourceDelegate/ObjC/CollectionView/Reloader/CollectionViewReloader.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/CollectionView/Reloader/CollectionViewReloader.h
@@ -8,6 +8,8 @@
 #import <UIKit/UIKit.h>
 #import "CollectionSectionItem.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Used in conjuction with CollectionDataSourceDelegate to provide a way
 /// to control collection view reloading behavior
 @protocol CollectionViewReloader <NSObject>
@@ -27,3 +29,5 @@
 @interface DefaultCollectionViewReloader : NSObject <CollectionViewReloader>
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/UI/DataSourceDelegate/ObjC/SectionItem.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/SectionItem.h
@@ -7,6 +7,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Base protocol for all possible kinds of sections
 /// collection view section, table view section...
 ///
@@ -14,3 +16,5 @@
 @protocol SectionItem <NSObject>
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/UI/DataSourceDelegate/ObjC/TableView/BaseTableCellItem/BaseTableCellItem.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/TableView/BaseTableCellItem/BaseTableCellItem.h
@@ -8,8 +8,11 @@
 #import <Foundation/Foundation.h>
 #import "TableCellItem.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Object which represents base table cell item
 @interface BaseTableCellItem : NSObject <TableCellItem>
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/Sources/UI/DataSourceDelegate/ObjC/TableView/BaseTableSection/BaseTableSection.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/TableView/BaseTableSection/BaseTableSection.h
@@ -9,6 +9,8 @@
 #import "TableCellItem.h"
 #import "TableSectionItem.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Represents blank section - without header or footer
 /// Used in conjuction with table view data source delegate
 /// for easy mapping items to single section without footer
@@ -20,3 +22,5 @@
 - (instancetype)initWithItems:(NSArray<id<TableCellItem>> *)items;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/UI/DataSourceDelegate/ObjC/TableView/Reloader/TableViewReloader.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/TableView/Reloader/TableViewReloader.h
@@ -8,6 +8,8 @@
 #import <UIKit/UIKit.h>
 #import "TableSectionItem.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Used in conjuction with TableDataSourceDelegate to provide a way
 /// to control table view reloading behavior
 @protocol TableViewReloader <NSObject>
@@ -28,3 +30,5 @@
 @interface DefaultTableViewReloader : NSObject <TableViewReloader>
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/UI/DataSourceDelegate/ObjC/TableView/Reloader/TableViewReloader.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/TableView/Reloader/TableViewReloader.h
@@ -16,10 +16,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Called when new data arrives and reload is necessary
 ///
-/// - Parameters:
-///   - tableView: Current table view
-///   - oldSections: Previous sections/items
-///   - newSections: New sections/items
+/// @param tableView Current table view
+/// @param oldSections Previous sections/items
+/// @param newSections New sections/items
 - (void)reloadTableView:(UITableView *)tableView
             oldSections:(NSArray<id<TableSectionItem>> *)oldSections
             newSections:(NSArray<id<TableSectionItem>> *)newSections;

--- a/Sources/UI/DataSourceDelegate/ObjC/TableView/TableCellItem.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/TableView/TableCellItem.h
@@ -30,17 +30,15 @@ NS_ASSUME_NONNULL_BEGIN
 /// Dequeued cell should be configured with current item before
 /// returning it.
 ///
-/// - Parameters:
-///   - tableView: parent table view
-///   - indexPath: index path of cell to configure
-/// - Returns: Dequeued, configured and reused cell
+/// @param tableView Parent table view
+/// @param indexPath Index path of cell to configure
 - (__kindof UITableViewCell *)cellFromTableView:(UITableView*)tableView at:(NSIndexPath*)indexPath;
 
 #pragma mark - Optional methods and properties
 
 /// Notifies cell item when user selects table view cell.
 ///
-/// - Parameter indexPath: index path of a selected cell
+/// @param indexPath Index path of a selected cell
 - (void)didSelectAt:(NSIndexPath *)indexPath;
 
 @end

--- a/Sources/UI/DataSourceDelegate/ObjC/TableView/TableCellItem.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/TableView/TableCellItem.h
@@ -7,6 +7,8 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Base interface for all table view cell items - used in conjuction with
 /// `TableDataSourceDelegate`
 @protocol TableCellItem <NSObject>
@@ -42,3 +44,5 @@
 - (void)didSelectAt:(NSIndexPath *)indexPath;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/UI/DataSourceDelegate/ObjC/TableView/TableDataSourceDelegate/TableDataSourceDelegate.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/TableView/TableDataSourceDelegate/TableDataSourceDelegate.h
@@ -38,8 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Object will have DefaultTableViewReloader as reloader.
 ///
-/// - Parameters:
-///   - tableView: Table view to control
+/// @param tableView Table view to control
 - (instancetype)initWithTableView:(UITableView *)tableView;
 
 /// Creates a new data source delegate object responsible for handling
@@ -51,9 +50,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Freely use `delegate` property since internally data source delegate will
 /// use pass through delegate.
 ///
-/// - Parameters:
-///   - tableView: Table view to control
-///   - reloader: Data reloader
+/// @param tableView Table view to control
+/// @param reloader Data reloader
 - (instancetype)initWithTableView:(UITableView *)tableView reloader:(id<TableViewReloader>)reloader;
 
 @end

--- a/Sources/UI/DataSourceDelegate/ObjC/TableView/TableDataSourceDelegate/TableDataSourceDelegate.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/TableView/TableDataSourceDelegate/TableDataSourceDelegate.h
@@ -12,6 +12,29 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ Indicates a mode of a tableView which `TableDataSourceDelegate` will manage.
+ 
+ TableViewModeClassic - use it if you don't need to display title or custom view in your header/footer view.
+ 
+ TableViewModeTitledHeaderFooter - use it if you need to display a title in your header/footer view.
+ It offers a possibility of using a title in header/footer view, but you don't need to implement it.
+ 
+ TableViewModeCustomHeaderFooter - use it if you need to display a custom view in your header/footer view.
+ It offers a possibility of using custom view in header/footer view, but you don't need to implement it.
+ */
+typedef NS_ENUM(NSUInteger, TableViewMode) {
+    
+    /// Classic tableView without titles or views in table headers or footers
+    TableViewModeClassic,
+    
+    /// TableView with optional title at header or footer.
+    TableViewModeTitledHeaderFooter,
+    
+    /// TableView with optional view at header or footer.
+    TableViewModeCustomHeaderFooter,
+};
+
 /// Object serving as a data source and delegate for a table view.
 /// Main purpose is to reduce a boilerplate when dealing with simple
 /// table view data displaying.
@@ -39,7 +62,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Object will have DefaultTableViewReloader as reloader.
 ///
 /// @param tableView Table view to control
-- (instancetype)initWithTableView:(UITableView *)tableView;
+/// @param mode Mode that indicates how table will be used
+- (instancetype)initWithTableView:(UITableView *)tableView
+                          forMode:(TableViewMode)mode;
 
 /// Creates a new data source delegate object responsible for handling
 /// table view data source and delegate logic.
@@ -51,8 +76,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// use pass through delegate.
 ///
 /// @param tableView Table view to control
+/// @param mode Mode that indicates how table will be used
 /// @param reloader Data reloader
-- (instancetype)initWithTableView:(UITableView *)tableView reloader:(id<TableViewReloader>)reloader;
+- (instancetype)initWithTableView:(UITableView *)tableView
+                          forMode:(TableViewMode)mode
+                         reloader:(id<TableViewReloader>)reloader;
 
 @end
 

--- a/Sources/UI/DataSourceDelegate/ObjC/TableView/TableDataSourceDelegate/TableDataSourceDelegate.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/TableView/TableDataSourceDelegate/TableDataSourceDelegate.h
@@ -10,6 +10,8 @@
 #import "TableCellItem.h"
 #import "TableViewReloader.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Object serving as a data source and delegate for a table view.
 /// Main purpose is to reduce a boilerplate when dealing with simple
 /// table view data displaying.
@@ -55,3 +57,5 @@
 - (instancetype)initWithTableView:(UITableView *)tableView reloader:(id<TableViewReloader>)reloader;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/UI/DataSourceDelegate/ObjC/TableView/TableDataSourceDelegate/TableDataSourceDelegate.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/TableView/TableDataSourceDelegate/TableDataSourceDelegate.h
@@ -43,12 +43,12 @@ typedef NS_ENUM(NSUInteger, TableViewMode) {
 @interface TableDataSourceDelegate : NSObject <UITableViewDelegate, UITableViewDataSource>
 
 /// Setting a sections will invoke internal reloader causing table view to refresh.
-@property (nonatomic, strong) NSArray<id<TableSectionItem>> *sections;
+@property (nonatomic, strong, nullable) NSArray<id<TableSectionItem>> *sections;
 
 /// Setting an items will invoke internal reloader causing table view to refresh.
 ///
 /// If there are multiple sections - then data is flattened to single array
-@property (nonatomic, strong) NSArray<id<TableCellItem>> *items;
+@property (nonatomic, strong, nullable) NSArray<id<TableCellItem>> *items;
 
 /// Creates a new data source delegate object responsible for handling
 /// table view data source and delegate logic.

--- a/Sources/UI/DataSourceDelegate/ObjC/TableView/TableDataSourceDelegate/TableDataSourceDelegate.m
+++ b/Sources/UI/DataSourceDelegate/ObjC/TableView/TableDataSourceDelegate/TableDataSourceDelegate.m
@@ -123,6 +123,26 @@
     return self.sections[indexPath.section].items[indexPath.row].height;
 }
 
+- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForHeaderInSection:(NSInteger)section
+{
+    return self.sections[section].estimatedHeaderHeight;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
+    return self.sections[section].headerHeight;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForFooterInSection:(NSInteger)section
+{
+    return self.sections[section].estimatedFooterHeight;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
+{
+    return self.sections[section].footerHeight;
+}
+
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
@@ -151,31 +171,9 @@
 
 @implementation CustomHeaderTableDataSourceDelegate
 
-// header
-- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForHeaderInSection:(NSInteger)section
-{
-    return self.sections[section].estimatedHeaderHeight;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    return self.sections[section].headerHeight;
-}
-
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
     return [self.sections[section] headerViewFromTableView:tableView at:section];
-}
-
-// footer
-- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForFooterInSection:(NSInteger)section
-{
-    return self.sections[section].estimatedFooterHeight;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    return self.sections[section].footerHeight;
 }
 
 - (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section

--- a/Sources/UI/DataSourceDelegate/ObjC/TableView/TableSectionItem.h
+++ b/Sources/UI/DataSourceDelegate/ObjC/TableView/TableSectionItem.h
@@ -9,6 +9,8 @@
 #import "SectionItem.h"
 #import "TableCellItem.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Base interface for all table view section items - used in conjuction with
 /// `TableDataSourceDelegate`
 @protocol TableSectionItem <NSObject, SectionItem>
@@ -31,3 +33,5 @@
 - (NSString *)titleForFooterFrom:(UITableView *)tableView at:(NSInteger)index;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/UI/TableDataSourceDelegateTestsObjC.m
+++ b/Tests/UI/TableDataSourceDelegateTestsObjC.m
@@ -214,6 +214,24 @@
     XCTAssertTrue([sections.firstObject isKindOfClass:BaseTableSection.class]);
 }
 
+- (void)testSectionHeaderSize
+{
+    CGFloat height = [self.tableDataSourceDelegate tableView:self.tableView heightForHeaderInSection:0];
+    CGFloat estimatedHeighteight = [self.tableDataSourceDelegate tableView:self.tableView estimatedHeightForHeaderInSection:0];
+    
+    XCTAssertEqual(estimatedHeighteight, 3);
+    XCTAssertEqual(height, 1);
+}
+
+- (void)testSectionFooterSize
+{
+    CGFloat height = [self.tableDataSourceDelegate tableView:self.tableView heightForFooterInSection:0];
+    CGFloat estimatedHeighteight = [self.tableDataSourceDelegate tableView:self.tableView estimatedHeightForFooterInSection:0];
+    
+    XCTAssertEqual(estimatedHeighteight, 4);
+    XCTAssertEqual(height, 2);
+}
+
 - (void)testHeightWhenSectionsAreNil
 {
     NSIndexPath *indexPath = [NSIndexPath indexPathForRow:0 inSection:0];
@@ -222,8 +240,15 @@
     
     XCTAssertEqual(self.tableDataSourceDelegate.sections.count, 0);
     XCTAssertEqual([self.tableDataSourceDelegate tableView:self.tableView numberOfRowsInSection:0], 0);
+    
     XCTAssertEqual([self.tableDataSourceDelegate tableView:self.tableView heightForRowAtIndexPath:indexPath], 0);
     XCTAssertEqual([self.tableDataSourceDelegate tableView:self.tableView estimatedHeightForRowAtIndexPath:indexPath], 0);
+    
+    XCTAssertEqual([self.tableDataSourceDelegate tableView:self.tableView heightForHeaderInSection:0], 0);
+    XCTAssertEqual([self.tableDataSourceDelegate tableView:self.tableView estimatedHeightForHeaderInSection:0], 0);
+    
+    XCTAssertEqual([self.tableDataSourceDelegate tableView:self.tableView heightForFooterInSection:0], 0);
+    XCTAssertEqual([self.tableDataSourceDelegate tableView:self.tableView estimatedHeightForFooterInSection:0], 0);
 }
 
 - (NSArray<TestSection*> *)createSections
@@ -305,24 +330,6 @@
     [super tearDown];
 }
 
-- (void)testSectionHeaderSize
-{
-    CGFloat height = [self.customHeaderTableDataSourceDelegate tableView:self.tableView heightForHeaderInSection:0];
-    CGFloat estimatedHeighteight = [self.customHeaderTableDataSourceDelegate tableView:self.tableView estimatedHeightForHeaderInSection:0];
-    
-    XCTAssertEqual(estimatedHeighteight, 3);
-    XCTAssertEqual(height, 1);
-}
-
-- (void)testSectionFooterSize
-{
-    CGFloat height = [self.customHeaderTableDataSourceDelegate tableView:self.tableView heightForFooterInSection:0];
-    CGFloat estimatedHeighteight = [self.customHeaderTableDataSourceDelegate tableView:self.tableView estimatedHeightForFooterInSection:0];
-    
-    XCTAssertEqual(estimatedHeighteight, 4);
-    XCTAssertEqual(height, 2);
-}
-
 - (void)testSectionHeaderFooterView
 {
     UIView *header = [self.customHeaderTableDataSourceDelegate tableView:self.tableView viewForHeaderInSection:0];
@@ -330,17 +337,6 @@
 
     XCTAssertNotNil(header);
     XCTAssertNotNil(footer);
-}
-
-- (void)testHeightWhenSectionsAreNil
-{
-    self.customHeaderTableDataSourceDelegate.sections = nil;
-
-    XCTAssertEqual([self.customHeaderTableDataSourceDelegate tableView:self.tableView heightForFooterInSection:0], 0);
-    XCTAssertEqual([self.customHeaderTableDataSourceDelegate tableView:self.tableView estimatedHeightForFooterInSection:0], 0);
-
-    XCTAssertEqual([self.customHeaderTableDataSourceDelegate tableView:self.tableView heightForHeaderInSection:0], 0);
-    XCTAssertEqual([self.customHeaderTableDataSourceDelegate tableView:self.tableView estimatedHeightForHeaderInSection:0], 0);
 }
 
 @end

--- a/Tests/UI/TableDataSourceDelegateTestsObjC.m
+++ b/Tests/UI/TableDataSourceDelegateTestsObjC.m
@@ -11,6 +11,8 @@
 #import "BaseTableCellItem.h"
 #import "BaseTableSection.h"
 
+#pragma mark - Cell
+
 @interface TestTableViewCell : UITableViewCell
 
 @end
@@ -18,6 +20,8 @@
 @implementation TestTableViewCell
 
 @end
+
+#pragma mark - Cell Item
 
 @interface TestCellItem: BaseTableCellItem
 
@@ -57,6 +61,8 @@
 }
 
 @end
+
+#pragma mark - Section
 
 @interface TestSection : BaseTableSection
 
@@ -108,6 +114,25 @@
 
 @end
 
+#pragma mark - Tests
+
+/*
+ We're testing TableDataSourceDelegate with 3 classes.
+ 
+ First one is testing a classic tableView (TableViewModeClassic), which is not supposed to have
+ title or customView at header/footer view.
+ 
+ Second is testing a titled tableView (TableViewModeTitledHeaderFooter),
+ which is supposed to have a title in header/footer view, but no customView.
+ This class inherits from the first one, in order to avoid duplicated section creation etc.
+ 
+ Third is testing a tableView with custom view at header/footer view (TableViewModeCustomHeaderFooter),
+ which is supposed to have a custom view in header/footer view, but no (system) title in it.
+ This class also inherits from the first one, in order to avoid duplicated section creation etc.
+ */
+
+#pragma mark - Classic
+
 @interface TableDataSourceDelegateTests : XCTestCase
 
 @property (nonatomic, strong) UITableView *tableView;
@@ -122,7 +147,9 @@
     [super setUp];
     
     self.tableView = [[UITableView alloc] init];
-    self.tableDataSourceDelegate = [[TableDataSourceDelegate alloc] initWithTableView:self.tableView];
+    self.tableDataSourceDelegate = [[TableDataSourceDelegate alloc]
+                                    initWithTableView:self.tableView
+                                    forMode:TableViewModeClassic];
     
     self.tableDataSourceDelegate.sections = self.createSections;
 }
@@ -149,33 +176,6 @@
     XCTAssertEqual(height, 50);
 }
 
-- (void)testSectionHeaderSize
-{
-    CGFloat height = [self.tableDataSourceDelegate tableView:self.tableView heightForHeaderInSection:0];
-    CGFloat estimatedHeighteight = [self.tableDataSourceDelegate tableView:self.tableView estimatedHeightForHeaderInSection:0];
-    
-    XCTAssertEqual(estimatedHeighteight, 3);
-    XCTAssertEqual(height, 1);
-}
-
-- (void)testSectionFooterSize
-{
-    CGFloat height = [self.tableDataSourceDelegate tableView:self.tableView heightForFooterInSection:0];
-    CGFloat estimatedHeighteight = [self.tableDataSourceDelegate tableView:self.tableView estimatedHeightForFooterInSection:0];
-    
-    XCTAssertEqual(estimatedHeighteight, 4);
-    XCTAssertEqual(height, 2);
-}
-
-- (void)testSectionTitles
-{
-    NSString *headerTitle = [self.tableDataSourceDelegate tableView:self.tableView titleForHeaderInSection:1];
-    NSString *footerTitle = [self.tableDataSourceDelegate tableView:self.tableView titleForFooterInSection:1];
-
-    XCTAssertEqual(headerTitle, @"Section2");
-    XCTAssertEqual(footerTitle, @"Section2");
-}
-
 - (void)testDidSelectInvocation
 {
     NSIndexPath *indexPath = [NSIndexPath indexPathForRow:0 inSection:0];
@@ -185,15 +185,6 @@
     TestCellItem *item = self.tableDataSourceDelegate.items[0];
 
     XCTAssertTrue(item.didSelectCalled);
-}
-
-- (void)testSectionHeaderFooterView
-{
-    UIView *header = [self.tableDataSourceDelegate tableView:self.tableView viewForHeaderInSection:0];
-    UIView *footer = [self.tableDataSourceDelegate tableView:self.tableView viewForFooterInSection:0];
-
-    XCTAssertNotNil(header);
-    XCTAssertNotNil(footer);
 }
 
 - (void)testCellType
@@ -233,11 +224,6 @@
     XCTAssertEqual([self.tableDataSourceDelegate tableView:self.tableView numberOfRowsInSection:0], 0);
     XCTAssertEqual([self.tableDataSourceDelegate tableView:self.tableView heightForRowAtIndexPath:indexPath], 0);
     XCTAssertEqual([self.tableDataSourceDelegate tableView:self.tableView estimatedHeightForRowAtIndexPath:indexPath], 0);
-    XCTAssertEqual([self.tableDataSourceDelegate tableView:self.tableView heightForFooterInSection:0], 0);
-    XCTAssertEqual([self.tableDataSourceDelegate tableView:self.tableView estimatedHeightForFooterInSection:0], 0);
-
-    XCTAssertEqual([self.tableDataSourceDelegate tableView:self.tableView heightForHeaderInSection:0], 0);
-    XCTAssertEqual([self.tableDataSourceDelegate tableView:self.tableView estimatedHeightForHeaderInSection:0], 0);
 }
 
 - (NSArray<TestSection*> *)createSections
@@ -252,6 +238,109 @@
     section2.title = @"Section2";
     
     return [[NSArray alloc] initWithObjects:section1, section2, nil];
+}
+
+@end
+
+#pragma mark - Titled
+
+@interface TitledTableDataSourceDelegateTests : TableDataSourceDelegateTests
+
+@property (nonatomic, strong) TableDataSourceDelegate *titledTableDataSourceDelegate;
+
+@end
+
+@implementation TitledTableDataSourceDelegateTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    self.titledTableDataSourceDelegate = [[TableDataSourceDelegate alloc]
+                                          initWithTableView:self.tableView
+                                          forMode:TableViewModeTitledHeaderFooter];
+
+    self.titledTableDataSourceDelegate.sections = self.createSections;
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+- (void)testSectionTitles
+{
+    NSString *headerTitle = [self.titledTableDataSourceDelegate tableView:self.tableView titleForHeaderInSection:1];
+    NSString *footerTitle = [self.titledTableDataSourceDelegate tableView:self.tableView titleForFooterInSection:1];
+
+    XCTAssertEqual(headerTitle, @"Section2");
+    XCTAssertEqual(footerTitle, @"Section2");
+}
+
+@end
+
+#pragma mark - Custom
+
+@interface CustomHeaderTableDataSourceDelegateTests : TableDataSourceDelegateTests
+
+@property (nonatomic, strong) TableDataSourceDelegate *customHeaderTableDataSourceDelegate;
+
+@end
+
+@implementation CustomHeaderTableDataSourceDelegateTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    self.customHeaderTableDataSourceDelegate = [[TableDataSourceDelegate alloc]
+                                          initWithTableView:self.tableView
+                                          forMode:TableViewModeCustomHeaderFooter];
+
+    self.customHeaderTableDataSourceDelegate.sections = self.createSections;
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+- (void)testSectionHeaderSize
+{
+    CGFloat height = [self.customHeaderTableDataSourceDelegate tableView:self.tableView heightForHeaderInSection:0];
+    CGFloat estimatedHeighteight = [self.customHeaderTableDataSourceDelegate tableView:self.tableView estimatedHeightForHeaderInSection:0];
+    
+    XCTAssertEqual(estimatedHeighteight, 3);
+    XCTAssertEqual(height, 1);
+}
+
+- (void)testSectionFooterSize
+{
+    CGFloat height = [self.customHeaderTableDataSourceDelegate tableView:self.tableView heightForFooterInSection:0];
+    CGFloat estimatedHeighteight = [self.customHeaderTableDataSourceDelegate tableView:self.tableView estimatedHeightForFooterInSection:0];
+    
+    XCTAssertEqual(estimatedHeighteight, 4);
+    XCTAssertEqual(height, 2);
+}
+
+- (void)testSectionHeaderFooterView
+{
+    UIView *header = [self.customHeaderTableDataSourceDelegate tableView:self.tableView viewForHeaderInSection:0];
+    UIView *footer = [self.customHeaderTableDataSourceDelegate tableView:self.tableView viewForFooterInSection:0];
+
+    XCTAssertNotNil(header);
+    XCTAssertNotNil(footer);
+}
+
+- (void)testHeightWhenSectionsAreNil
+{
+    self.customHeaderTableDataSourceDelegate.sections = nil;
+
+    XCTAssertEqual([self.customHeaderTableDataSourceDelegate tableView:self.tableView heightForFooterInSection:0], 0);
+    XCTAssertEqual([self.customHeaderTableDataSourceDelegate tableView:self.tableView estimatedHeightForFooterInSection:0], 0);
+
+    XCTAssertEqual([self.customHeaderTableDataSourceDelegate tableView:self.tableView heightForHeaderInSection:0], 0);
+    XCTAssertEqual([self.customHeaderTableDataSourceDelegate tableView:self.tableView estimatedHeightForHeaderInSection:0], 0);
 }
 
 @end


### PR DESCRIPTION
# Description
I've implemented an enum that represents a mode of how UITableView should look like in ObjC version of `TableDataSourceDelegate`. That mode indicates which kind/subclass of `TableDataSourceDelegate` will be used to manage a `UITableView`.

Please include a summary of the feature you have added.
Since tableView's delegate must not implement `viewForHeaderInSection` (or `viewForFooterInSection`) if you want to use `titleForHeaderInSection` (or `titleForFooterInSection`), I created an enum that represents a mode of how table should look like, and depending on the enum case, a `TableDataSourceDelegate` will instantiate a different subclass and assign it to `self`. That way, you're able to use tableView without any title/view in header/footer view, or with it.

# Checklist:

<!--
Put `x` inside brackets for confirmation: [x]
-->

- [x] Have checked there is no same component already in catalog.
- [x] Have created a sufficient example or wrote tests for it.
- [x] Code is structured, well written using standard Swift coding style.
- [x] All public methods and properties have meaningful and concise documentation.
- [x] Used `public` modifier for all method and properties that could be changed from user of your feature, and `private` for internal properties.
- [x] Removed any reference to the project that piece of code was created in.
- [x] Reduced the dependencies to minimum.
