### PR TITLE
Add compactMap to drivers and signals.

### DIFF
--- a/Sources/RxCocoa/Driver/Driver+Utility.swift
+++ b/Sources/RxCocoa/Driver/Driver+Utility.swift
@@ -20,10 +20,22 @@ public extension SharedSequenceConvertibleType where SharingStrategy == DriverSh
     }
     
     /// Safely unwraps optional value from chain
-    func unwrap<T>() -> Driver<T> where Element == Optional<T> {
+    func compactMap<T>() -> Driver<T> where Element == Optional<T> {
+        return self.compactMap { $0 }
+    }
+    
+    /**
+    Projects each element of this driver sequence into an optional form and filters all optional results.
+
+    - parameter transform: A transform function to apply to each source element and which returns an element or nil.
+    - returns: An observable sequence whose elements are the result of filtering the transform function for each element of the source.
+
+    */
+    func compactMap<Result>(transform: @escaping (Element) throws -> (Result?)) -> Driver<Result> {
         return self
-            .filter { $0 != nil }
-            .map { $0! }
+            .asObservable()
+            .compactMap(transform)
+            .asDriverOnErrorComplete()
     }
     
     /// Returns a sequence by the source observable sequence

--- a/Sources/RxCocoa/Signal/Signal+Utility.swift
+++ b/Sources/RxCocoa/Signal/Signal+Utility.swift
@@ -19,12 +19,24 @@ public extension SharedSequenceConvertibleType where SharingStrategy == SignalSh
     func emit(_ relay: PublishRelay<Element>) -> Disposable {
         return emit(onNext: { e in relay.accept(e) })
     }
-
+    
     /// Safely unwraps optional value from chain
-    func unwrap<T>() -> Signal<T> where Element == Optional<T> {
+    func compactMap<T>() -> Signal<T> where Element == Optional<T> {
+        return self.compactMap { $0 }
+    }
+    
+    /**
+    Projects each element of this signal sequence into an optional form and filters all optional results.
+
+    - parameter transform: A transform function to apply to each source element and which returns an element or nil.
+    - returns: An observable sequence whose elements are the result of filtering the transform function for each element of the source.
+
+    */
+    func compactMap<Result>(transform: @escaping (Element) throws -> (Result?)) -> Signal<Result> {
         return self
-            .filter { $0 != nil }
-            .map { $0! }
+            .asObservable()
+            .compactMap(transform)
+            .asSignalOnErrorComplete()
     }
 
     /// Returns a sequence by the source observable sequence

--- a/Sources/RxSwift/Observable/Observable+Utility.swift
+++ b/Sources/RxSwift/Observable/Observable+Utility.swift
@@ -18,6 +18,13 @@ public extension ObservableType {
         return asDriver(onErrorDriveWith: .empty())
     }
     
+    /// Converts current Observable sequence to Signal, completing on error event.
+    ///
+    /// - Returns: Signal - completing on error event
+    func asSignalOnErrorComplete() -> Signal<Element> {
+        return self.asSignal(onErrorSignalWith: .empty())
+    }
+    
     /// Maps each sequence elements to given value.
     ///
     /// - Parameter value: Value to map


### PR DESCRIPTION
# Description

Replaced `unwrap` with `compactMap` to match with Observable's `compactMap`.

# Checklist:
- [x] Have checked there is no same component already in catalog.
- [x] Have created a sufficient example or wrote tests for it.
- [x] Code is structured, well written using standard Swift coding style.
- [x] All public methods and properties have meaningful and concise documentation.
- [x] Used `public` modifier for all method and properties that could be changed from user of your feature, and `private` for internal properties.
- [x] Removed any reference to the project that piece of code was created in.
- [x] Reduced the dependencies to minimum.
