### PR TITLE
Using provided keyPath & decoder when decoding response object.

### DIFF
--- a/Sources/Networking/Service/APIService.swift
+++ b/Sources/Networking/Service/APIService.swift
@@ -49,7 +49,7 @@ open class APIService: APIServiceable {
         return sessionManager
             .request(router)
             .validate()
-            .responseDecodableObject { completion($0.result) }
+            .responseDecodableObject(keyPath: keyPath, decoder: decoder) { completion($0.result) }
     }
 
     @discardableResult


### PR DESCRIPTION
# Description

Using provided keyPath & decoder when decoding response object.

# Checklist:

<!--
Put `x` inside brackets for confirmation: [x]
-->

- [x] Have checked there is no same component already in catalog.
- [x] Have created a sufficient example or wrote tests for it.
- [x] Code is structured, well written using standard Swift coding style.
- [x] All public methods and properties have meaningful and concise documentation.
- [x] Used `public` modifier for all method and properties that could be changed from user of your feature, and `private` for internal properties.
- [x] Removed any reference to the project that piece of code was created in.
- [x] Reduced the dependencies to minimum.
