### PR TITLE
Replace class with AnyObject

### DIFF
--- a/Sources/Networking/Service/APIService.swift
+++ b/Sources/Networking/Service/APIService.swift
@@ -9,7 +9,7 @@ import Foundation
 import Alamofire
 
 /// Base protocol for API networking communication.
-public protocol APIServiceable: class {
+public protocol APIServiceable: AnyObject {
 
     @discardableResult
     func request<T: Decodable>(

--- a/Sources/UI/UIButton/UIButton+Toggle.swift
+++ b/Sources/UI/UIButton/UIButton+Toggle.swift
@@ -25,7 +25,7 @@ public enum ToggleState: Equatable {
     }
 }
 
-public protocol Togglable: class {
+public protocol Togglable: AnyObject {
 
     /// Current state
     var toggleState: ToggleState { get }

--- a/Sources/VIPER Interfaces/BaseWireframe.swift
+++ b/Sources/VIPER Interfaces/BaseWireframe.swift
@@ -3,7 +3,7 @@ import RxSwift
 import RxCocoa
 import SafariServices
 
-protocol WireframeInterface: class {
+protocol WireframeInterface: AnyObject {
     func openAlert<T>(
         title: String?,
         message: String?,

--- a/Sources/VIPER Interfaces/InteractorInterface.swift
+++ b/Sources/VIPER Interfaces/InteractorInterface.swift
@@ -1,4 +1,4 @@
-protocol InteractorInterface: class {
+protocol InteractorInterface: AnyObject {
 }
 
 extension InteractorInterface {

--- a/Sources/VIPER Interfaces/PresenterInterface.swift
+++ b/Sources/VIPER Interfaces/PresenterInterface.swift
@@ -1,4 +1,4 @@
-protocol PresenterInterface: class {
+protocol PresenterInterface: AnyObject {
     func viewDidLoad()
     func viewWillAppear(animated: Bool)
     func viewDidAppear(animated: Bool)

--- a/Sources/VIPER Interfaces/Progressable.swift
+++ b/Sources/VIPER Interfaces/Progressable.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol Progressable: class {
+public protocol Progressable: AnyObject {
     func showLoading()
     func hideLoading()
     

--- a/Sources/VIPER Interfaces/ViewInterface.swift
+++ b/Sources/VIPER Interfaces/ViewInterface.swift
@@ -1,4 +1,4 @@
-protocol ViewInterface: class {
+protocol ViewInterface: AnyObject {
 }
 
 extension ViewInterface {


### PR DESCRIPTION
# Description

Updated class with AnyObject since class is getting deprecated and receiving warnings in Xcode 12.5

# Checklist:

<!--
Put `x` inside brackets for confirmation: [x]
-->

- [x] Have checked there is no same component already in catalog.
- [x] Have created a sufficient example or wrote tests for it.
- [x] Code is structured, well written using standard Swift coding style.
- [x] All public methods and properties have meaningful and concise documentation.
- [x] Used `public` modifier for all method and properties that could be changed from user of your feature, and `private` for internal properties.
- [x] Removed any reference to the project that piece of code was created in.
- [x] Reduced the dependencies to minimum.
