### PR TITLE
Disable unavailable_function in presenter interface file

### DIFF
--- a/Sources/VIPER Interfaces/PresenterInterface.swift
+++ b/Sources/VIPER Interfaces/PresenterInterface.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable unavailable_function
+
 protocol PresenterInterface: AnyObject {
     func viewDidLoad()
     func viewWillAppear(animated: Bool)


### PR DESCRIPTION
# Description

In this PR, I have disabled `unavailable_function` swiftlint warning inside of the `PresenterInterface` file.

# Checklist:

<!--
Put `x` inside brackets for confirmation: [x]
-->

- [x] Have checked there is no same component already in catalog.
- [ ] Have created a sufficient example or wrote tests for it.
- [x] Code is structured, well written using standard Swift coding style.
- [ ] All public methods and properties have meaningful and concise documentation.
- [ ] Used `public` modifier for all method and properties that could be changed from user of your feature, and `private` for internal properties.
- [ ] Removed any reference to the project that piece of code was created in.
- [x] Reduced the dependencies to minimum.
