### PR TITLE
removed toCombineResult

### DIFF
--- a/Sources/Foundation/Result/Result+Combine.swift
+++ b/Sources/Foundation/Result/Result+Combine.swift
@@ -10,15 +10,6 @@ import Foundation
 
 public extension Result {
 
-    var toCombineResult: Result<Success, Failure> {
-        switch self {
-        case .failure(let error):
-            return .failure(error)
-        case .success(let value):
-            return .success(value)
-        }
-    }
-
     var toCompletableResult: Result<Void, Failure> {
         switch self {
         case .failure(let error):

--- a/Sources/Networking/Combine/APIService+Combine.swift
+++ b/Sources/Networking/Combine/APIService+Combine.swift
@@ -27,7 +27,7 @@ public extension APIServiceable {
                 decoder: decoder,
                 router: router,
                 session: session,
-                completion: { promise($0) }
+                completion: promise
             )
         }.eraseToAnyPublisher()
     }

--- a/Sources/Networking/Combine/APIService+Combine.swift
+++ b/Sources/Networking/Combine/APIService+Combine.swift
@@ -27,7 +27,7 @@ public extension APIServiceable {
                 decoder: decoder,
                 router: router,
                 session: session,
-                completion: { promise($0.toCombineResult) }
+                completion: { promise($0) }
             )
         }.eraseToAnyPublisher()
     }


### PR DESCRIPTION
# Description

Removed the `toCombineResult` property since it transformed itself to itself.
@MateMasnov nice catch! 🙌 

# Checklist:

<!--
Put `x` inside brackets for confirmation: [x]
-->

- [ x ] Have checked there is no same component already in catalog.
- [ x ] Have created a sufficient example or wrote tests for it.
- [ x ] Code is structured, well written using standard Swift coding style.
- [ x ] All public methods and properties have meaningful and concise documentation.
- [ x ] Used `public` modifier for all method and properties that could be changed from user of your feature, and `private` for internal properties.
- [ x ] Removed any reference to the project that piece of code was created in.
- [ x ] Reduced the dependencies to minimum.
