### PR TITLE
Adds the ability to specify a view's drop shadow as defined in Figma

### DIFF
--- a/Catalog/Examples/UI/UIView Modifiers/UIViewModifiers/UIViewModifiers.storyboard
+++ b/Catalog/Examples/UI/UIView Modifiers/UIViewModifiers/UIViewModifiers.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="AK6-lf-ZPI">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="AK6-lf-ZPI">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -22,10 +20,10 @@
                                 <rect key="frame" x="16" y="60" width="382" height="786"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Ey7-Ux-mty">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="184.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="144.5"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oQm-U8-41C">
-                                                <rect key="frame" x="0.0" y="0.0" width="382" height="156"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="382" height="116"/>
                                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
@@ -34,7 +32,7 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Corner radius" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R70-BL-gPG">
-                                                <rect key="frame" x="0.0" y="164" width="382" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="124" width="382" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -42,10 +40,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="uVG-3u-ReU">
-                                        <rect key="frame" x="0.0" y="200.5" width="382" height="184.5"/>
+                                        <rect key="frame" x="0.0" y="160.5" width="382" height="144.5"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kQJ-kn-ab6">
-                                                <rect key="frame" x="0.0" y="0.0" width="382" height="156"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="382" height="116"/>
                                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
@@ -54,7 +52,7 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Border" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CrW-UZ-Qb4">
-                                                <rect key="frame" x="0.0" y="164" width="382" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="124" width="382" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -62,10 +60,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="WFR-k9-7Qd">
-                                        <rect key="frame" x="0.0" y="401" width="382" height="184.5"/>
+                                        <rect key="frame" x="0.0" y="321" width="382" height="144"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X9T-vH-2D3">
-                                                <rect key="frame" x="0.0" y="0.0" width="382" height="156"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="382" height="115.5"/>
                                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
@@ -80,7 +78,7 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Corner radius + Border" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wwO-FP-r2f">
-                                                <rect key="frame" x="0.0" y="164" width="382" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="123.5" width="382" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -88,14 +86,29 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="SUJ-8n-fs5">
-                                        <rect key="frame" x="0.0" y="601.5" width="382" height="184.5"/>
+                                        <rect key="frame" x="0.0" y="481" width="382" height="144.5"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="31X-6q-thu">
-                                                <rect key="frame" x="0.0" y="0.0" width="382" height="156"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="382" height="116"/>
                                                 <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Corner radius + Border (from code)" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rNI-KP-CjA">
-                                                <rect key="frame" x="0.0" y="164" width="382" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="124" width="382" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="64g-qa-kTB">
+                                        <rect key="frame" x="0.0" y="641.5" width="382" height="144.5"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="krR-MU-GM5">
+                                                <rect key="frame" x="0.0" y="0.0" width="382" height="116"/>
+                                                <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Shadow from Figma parameters" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6So-dl-nwq">
+                                                <rect key="frame" x="0.0" y="124" width="382" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -105,6 +118,7 @@
                                 </subviews>
                             </stackView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="wa2-8K-VIL"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="wa2-8K-VIL" firstAttribute="trailing" secondItem="hCd-sH-0Cz" secondAttribute="trailing" constant="16" id="Ptl-Cv-53a"/>
@@ -112,10 +126,10 @@
                             <constraint firstItem="wa2-8K-VIL" firstAttribute="bottom" secondItem="hCd-sH-0Cz" secondAttribute="bottom" constant="16" id="toN-Rq-pDk"/>
                             <constraint firstItem="hCd-sH-0Cz" firstAttribute="leading" secondItem="wa2-8K-VIL" secondAttribute="leading" constant="16" id="zA9-2z-dyY"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="wa2-8K-VIL"/>
                     </view>
                     <connections>
                         <outlet property="modifiedView" destination="31X-6q-thu" id="gXn-MP-Qwk"/>
+                        <outlet property="shadowView" destination="krR-MU-GM5" id="LBj-DS-L5V"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Wg9-zw-gCi" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Catalog/Examples/UI/UIView Modifiers/UIViewModifiers/UIViewModifiersViewController.swift
+++ b/Catalog/Examples/UI/UIView Modifiers/UIViewModifiers/UIViewModifiersViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 class UIViewModifiersViewController: UIViewController {
 
     @IBOutlet private weak var modifiedView: UIView!
+    @IBOutlet private weak var shadowView: UIView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -18,6 +19,12 @@ class UIViewModifiersViewController: UIViewController {
         modifiedView.borderColor = .yellow
         modifiedView.borderWidth = 2
         modifiedView.cornerRadius = 30
+
+        shadowView.applyFigmaShadow(
+            opacity: 0.5,
+            offset: CGSize(width: 0, height: 4),
+            blur: 8
+        )
     }
 }
 

--- a/Sources/UI/UIView/UIView+LayerModifiers.swift
+++ b/Sources/UI/UIView/UIView+LayerModifiers.swift
@@ -44,4 +44,37 @@ public extension UIView {
         }
     }
 
+    /// Adds a rectangular drop shadow to a view.
+    ///
+    /// This method allows you to configure your shadow exactly as the
+    /// designer specified it in Figma or Sketch.
+    ///
+    /// - Parameters:
+    ///   - color: The base color of the shadow. If not defined black color is used as is most often the case.
+    ///   - opacity: The opacity of the shadow.
+    ///   - offset: The horizontal and vertical positioning of the shadow relative to the view.
+    ///   - blur: The blur parameter as defined in Figma/Sketch.
+    ///   - spread: The blur parameter as defined in Figma/Sketch.
+    func applyFigmaShadow(
+        color: UIColor = .black,
+        opacity: Float,
+        offset: CGSize = .zero,
+        blur: CGFloat,
+        spread: CGFloat = 0
+    ) {
+      layer.masksToBounds = false
+      layer.shadowColor = color.cgColor
+      layer.shadowOpacity = opacity
+      layer.shadowOffset = offset
+      layer.shadowRadius = blur / UIScreen.main.scale
+
+      if spread == 0 {
+        layer.shadowPath = nil
+      } else {
+        let dx = -spread
+        let rect = bounds.insetBy(dx: dx, dy: dx)
+        layer.shadowPath = UIBezierPath(rect: rect).cgPath
+      }
+    }
+
 }

--- a/Sources/UI/UIView/UIView+LayerModifiers.swift
+++ b/Sources/UI/UIView/UIView+LayerModifiers.swift
@@ -54,7 +54,7 @@ public extension UIView {
     ///   - opacity: The opacity of the shadow.
     ///   - offset: The horizontal and vertical positioning of the shadow relative to the view.
     ///   - blur: The blur parameter as defined in Figma/Sketch.
-    ///   - spread: The blur parameter as defined in Figma/Sketch.
+    ///   - spread: The spread parameter as defined in Figma/Sketch.
     func applyFigmaShadow(
         color: UIColor = .black,
         opacity: Float,


### PR DESCRIPTION
# Description

This `UIView` extension method allows you to set a drop shadow using the blur & spread configuration method which is used in Figma/Sketch as opposed to just using iOS's radius parameter which inaccurately reproduces the shadow.

# Checklist:

- [x] Have checked there is no same component already in catalog.
- [x] Have created a sufficient example or wrote tests for it.
- [x] Code is structured, well written using standard Swift coding style.
- [x] All public methods and properties have meaningful and concise documentation.
- [x] Used `public` modifier for all method and properties that could be changed from user of your feature, and `private` for internal properties.
- [x] Removed any reference to the project that piece of code was created in.
- [x] Reduced the dependencies to minimum.
