### PR TITLE
Implement TaskPublisher and ThrowingTaskPublisher

### DIFF
--- a/Catalog.xcodeproj/project.pbxproj
+++ b/Catalog.xcodeproj/project.pbxproj
@@ -264,6 +264,9 @@
 		FA2586B02982C59700CFA350 /* DispatchQueueExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2586AF2982C59700CFA350 /* DispatchQueueExtensions.swift */; };
 		FA2586B22982C5AA00CFA350 /* LoggerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2586B12982C5AA00CFA350 /* LoggerExtensions.swift */; };
 		FA2586B42982CAED00CFA350 /* MigrationObjectExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2586B32982CAED00CFA350 /* MigrationObjectExtensions.swift */; };
+		FA3B914229AC9F1200ECFFA4 /* ThrowingTaskPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3B914029AC9F1200ECFFA4 /* ThrowingTaskPublisher.swift */; };
+		FA3B914329AC9F1200ECFFA4 /* TaskPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3B914129AC9F1200ECFFA4 /* TaskPublisher.swift */; };
+		FA3B914529AC9F4500ECFFA4 /* TaskPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3B914429AC9F4500ECFFA4 /* TaskPublisherTests.swift */; };
 		FA8892C7298BDA5300283B02 /* ListExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8892C6298BDA5300283B02 /* ListExtensions.swift */; };
 		FA8892C9298BDABE00283B02 /* ListExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8892C8298BDABE00283B02 /* ListExtensionsTests.swift */; };
 		FA8892CB298BDB3B00283B02 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8892CA298BDB3B00283B02 /* Helpers.swift */; };
@@ -575,6 +578,9 @@
 		FA2586AF2982C59700CFA350 /* DispatchQueueExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchQueueExtensions.swift; sourceTree = "<group>"; };
 		FA2586B12982C5AA00CFA350 /* LoggerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerExtensions.swift; sourceTree = "<group>"; };
 		FA2586B32982CAED00CFA350 /* MigrationObjectExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationObjectExtensions.swift; sourceTree = "<group>"; };
+		FA3B914029AC9F1200ECFFA4 /* ThrowingTaskPublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrowingTaskPublisher.swift; sourceTree = "<group>"; };
+		FA3B914129AC9F1200ECFFA4 /* TaskPublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskPublisher.swift; sourceTree = "<group>"; };
+		FA3B914429AC9F4500ECFFA4 /* TaskPublisherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskPublisherTests.swift; sourceTree = "<group>"; };
 		FA8892C6298BDA5300283B02 /* ListExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListExtensions.swift; sourceTree = "<group>"; };
 		FA8892C8298BDABE00283B02 /* ListExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListExtensionsTests.swift; sourceTree = "<group>"; };
 		FA8892CA298BDB3B00283B02 /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
@@ -1409,6 +1415,7 @@
 		372448C6273289CB00016144 /* Combine */ = {
 			isa = PBXGroup;
 			children = (
+				FA3B914429AC9F4500ECFFA4 /* TaskPublisherTests.swift */,
 				372448C7273289D400016144 /* CombinePagingTests.swift */,
 			);
 			path = Combine;
@@ -1561,6 +1568,7 @@
 		37818944273176A0004E6BE3 /* Combine */ = {
 			isa = PBXGroup;
 			children = (
+				FA3B913F29AC9F1200ECFFA4 /* AsyncAwait */,
 				3781894A273179EF004E6BE3 /* Paging */,
 				37818945273176C0004E6BE3 /* Extensions */,
 			);
@@ -2099,6 +2107,15 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		FA3B913F29AC9F1200ECFFA4 /* AsyncAwait */ = {
+			isa = PBXGroup;
+			children = (
+				FA3B914029AC9F1200ECFFA4 /* ThrowingTaskPublisher.swift */,
+				FA3B914129AC9F1200ECFFA4 /* TaskPublisher.swift */,
+			);
+			path = AsyncAwait;
+			sourceTree = "<group>";
+		};
 		FA8892D1298BDDE600283B02 /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
@@ -2370,6 +2387,7 @@
 				0AB524182210AF9A00F35F52 /* Parameters+Filter.swift in Sources */,
 				0612E33F22D32A750081BCF6 /* UIViewModifiersViewController.swift in Sources */,
 				FA8892D4298BDEB900283B02 /* ValidatedDelete.swift in Sources */,
+				FA3B914329AC9F1200ECFFA4 /* TaskPublisher.swift in Sources */,
 				0A1FAFF92406BB6F000F72D6 /* SessionManager.swift in Sources */,
 				0AB524222210B3CB00F35F52 /* URL+Append.swift in Sources */,
 				0A1DFE4F236EE8C5000F2538 /* Signal+Utility.swift in Sources */,
@@ -2512,6 +2530,7 @@
 				A8D4BE892689A023002D8202 /* LoggingFormatter.swift in Sources */,
 				81B01CAE25EE8C7E0058D8E0 /* UICollectionView+Register.swift in Sources */,
 				3781894127316BCB004E6BE3 /* CombineNetworkingViewController.swift in Sources */,
+				FA3B914229AC9F1200ECFFA4 /* ThrowingTaskPublisher.swift in Sources */,
 				0AB524142210AF1000F35F52 /* Parameters+Sorting.swift in Sources */,
 				0A0C8CFE22492E2C0071011F /* EncodableParams.swift in Sources */,
 				0A54436422718AB100F26468 /* RxNetworkingInteractor.swift in Sources */,
@@ -2557,6 +2576,7 @@
 				536E5ADD225F33B900EF01A6 /* String+InsertingTests.swift in Sources */,
 				536E5AE0225F36CF00EF01A6 /* Collection+Grouping.swift in Sources */,
 				536E5ACC225F2BF500EF01A6 /* Date+Addition.swift in Sources */,
+				FA3B914529AC9F4500ECFFA4 /* TaskPublisherTests.swift in Sources */,
 				536E5AC0225F20A600EF01A6 /* Bool+FunctionTests.swift in Sources */,
 				FA8892CB298BDB3B00283B02 /* Helpers.swift in Sources */,
 				536E5AB7225F1BB300EF01A6 /* Bool+MappingTests.swift in Sources */,

--- a/Sources/Combine/AsyncAwait/TaskPublisher.swift
+++ b/Sources/Combine/AsyncAwait/TaskPublisher.swift
@@ -1,0 +1,70 @@
+import Combine
+
+/// A bridge between async await and Combine
+/// It allows to convert async function to Combine publisher
+public final class TaskPublisher<Success> {
+    public typealias Work = () async -> Success
+    private let work: Work
+
+    public init(_ work: @escaping Work) {
+        self.work = work
+    }
+}
+
+@available(iOS 13.0, *)
+extension TaskPublisher: Publisher {
+    public typealias Output = Success
+    public typealias Failure = Never
+
+    public func receive<S>(subscriber: S) where S: Subscriber, Never == S.Failure, Output == S.Input {
+        let subscription = Subscription<S>(work, downstream: subscriber)
+        subscriber.receive(subscription: subscription)
+    }
+}
+
+@available(iOS 13.0, *)
+extension TaskPublisher {
+    actor Subscription<Downstream: Subscriber> where Downstream.Input == Output, Downstream.Failure == Never {
+        let work: Work
+        var task: Task<Void, Never>?
+        var downstream: Downstream?
+
+        init(_ work: @escaping Work, downstream: Downstream? = nil) {
+            self.work = work
+            self.downstream = downstream
+        }
+
+        func cleanup() {
+            task = nil
+            downstream = nil
+        }
+
+        func cancelAndCleanup() {
+            task?.cancel()
+            cleanup()
+        }
+
+        func receive(_ value: Output) {
+            _ = downstream?.receive(value)
+            downstream?.receive(completion: .finished)
+            cleanup()
+        }
+
+        func runWork() {
+            guard task == nil else { return }
+            task = Task<Void, Never> { receive(await work()) }
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension TaskPublisher.Subscription: Subscription {
+    nonisolated func request(_ demand: Subscribers.Demand) {
+        guard demand > 0 else { return }
+        Task<Void, Never> { await runWork() }
+    }
+
+    nonisolated func cancel() {
+        Task<Void, Never> { await cancelAndCleanup() }
+    }
+}

--- a/Sources/Combine/AsyncAwait/ThrowingTaskPublisher.swift
+++ b/Sources/Combine/AsyncAwait/ThrowingTaskPublisher.swift
@@ -1,0 +1,82 @@
+import Combine
+
+/// A bridge between async await and Combine
+/// It allows to convert throwing async function to Combine publisher
+@available(iOS 13.0, *)
+public final class ThrowingTaskPublisher<Success> {
+    public typealias Work = () async throws -> Success
+    private let work: Work
+
+    public init(_ work: @escaping Work) {
+        self.work = work
+    }
+}
+
+@available(iOS 13.0, *)
+extension ThrowingTaskPublisher: Publisher {
+    public typealias Output = Success
+    public typealias Failure = Error
+
+    public func receive<S>(subscriber: S) where S: Subscriber, Failure == S.Failure, Output == S.Input {
+        let subscription = Subscription<S>(work, downstream: subscriber)
+        subscriber.receive(subscription: subscription)
+    }
+}
+
+@available(iOS 13.0, *)
+extension ThrowingTaskPublisher {
+    actor Subscription<Downstream: Subscriber> where Downstream.Input == Output, Downstream.Failure == Failure {
+        let work: Work
+        var task: Task<Void, Never>?
+        var downstream: Downstream?
+
+        init(_ work: @escaping Work, downstream: Downstream? = nil) {
+            self.work = work
+            self.downstream = downstream
+        }
+
+        func cleanup() {
+            task = nil
+            downstream = nil
+        }
+
+        func cancelAndCleanup() {
+            task?.cancel()
+            cleanup()
+        }
+
+        func receive(_ value: Output) {
+            _ = downstream?.receive(value)
+            downstream?.receive(completion: .finished)
+            cleanup()
+        }
+
+        func fail(_ error: Failure) {
+            downstream?.receive(completion: .failure(error))
+            cleanup()
+        }
+
+        func runWork() {
+            guard task == nil else { return }
+            task = Task<Void, Never> {
+                do {
+                    receive(try await work())
+                } catch {
+                    fail(error)
+                }
+            }
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension ThrowingTaskPublisher.Subscription: Subscription {
+    nonisolated func request(_ demand: Subscribers.Demand) {
+        guard demand > 0 else { return }
+        Task<Void, Never> { await runWork() }
+    }
+
+    nonisolated func cancel() {
+        Task<Void, Never> { await cancelAndCleanup() }
+    }
+}

--- a/Tests/Combine/TaskPublisherTests.swift
+++ b/Tests/Combine/TaskPublisherTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+import Combine
+@testable import Catalog
+
+@available(iOS 13.0, *)
+class TaskPublisherTests: XCTestCase {
+    private var bag = Set<AnyCancellable>()
+
+    func testCompletesWithoutError() {
+        func work() async throws { }
+
+        let publisher = ThrowingTaskPublisher(work)
+        let expectation = expectation(description: "")
+
+        publisher.sink(
+            receiveCompletion: { event in
+                expectation.fulfill()
+                guard case .finished = event else {
+                    XCTFail("Task should complete successfully")
+                    return
+                }
+            },
+            receiveValue: { _ in }
+        )
+        .store(in: &bag)
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCompletesWithError() {
+        struct ErrorMock: Error { }
+        func work() async throws { throw ErrorMock() }
+
+        let publisher = ThrowingTaskPublisher(work)
+        let expectation = expectation(description: "")
+
+        publisher.sink(
+            receiveCompletion: { event in
+                expectation.fulfill()
+                guard case .failure(let error) = event else {
+                    XCTFail("Task should fail")
+                    return
+                }
+                XCTAssertTrue(error is ErrorMock)
+            },
+            receiveValue: { _ in }
+        )
+        .store(in: &bag)
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testTaskCancelledOnSubscriptionCancel() {
+        let taskCancelled = PassthroughSubject<Void, Never>()
+        let taskStartedExpectation = expectation(description: "Task Started")
+        let taskCancelledExpectation = expectation(description: "Task Cancelled")
+        taskCancelled.sink(
+            receiveCompletion: { _ in },
+            receiveValue: { taskCancelledExpectation.fulfill() }
+        )
+        .store(in: &bag)
+
+        func work() async throws {
+            taskStartedExpectation.fulfill()
+            while true {
+                await Task.yield()
+                if Task.isCancelled { break }
+            }
+            taskCancelled.send(())
+        }
+
+        let publisher = ThrowingTaskPublisher(work)
+        let subscription = publisher.sink(receiveCompletion: { _ in }, receiveValue: { })
+
+        // Wait for task to be started before cancelling it
+        wait(for: [taskStartedExpectation], timeout: 1)
+
+        subscription.cancel()
+
+        wait(for: [taskCancelledExpectation], timeout: 1)
+    }
+}


### PR DESCRIPTION
# Description

These allow to convert between async await and Combine.

# Checklist:

<!--
Put `x` inside brackets for confirmation: [x]
-->

- [x] Have checked there is no same component already in catalog.
- [x] Have created a sufficient example or wrote tests for it.
- [x] Code is structured, well written using standard Swift coding style.
- [x] All public methods and properties have meaningful and concise documentation.
- [x] Used `public` modifier for all method and properties that could be changed from user of your feature, and `private` for internal properties.
- [x] Removed any reference to the project that piece of code was created in.
- [x] Reduced the dependencies to minimum.
